### PR TITLE
Make featured box content smaller to fit box

### DIFF
--- a/src/main/webapp/resources/app/js/dataset/featuredDatasetsDirective.html
+++ b/src/main/webapp/resources/app/js/dataset/featuredDatasetsDirective.html
@@ -15,7 +15,7 @@
       <div class="cell large-6 " ng-repeat="featuredDataset in featuredDatasets">
         <div class="grid-y panel callout primary" style="height:24rem;">
           <div class="cell shrink large-cell-block">
-            <h4>{{featuredDataset.title}}</h4>
+            <h5>{{featuredDataset.title}}</h5>
           </div>
           <div class="cell auto large-cell-block">
             <p class="featured-dataset-comment">


### PR DESCRIPTION
Featured dataset box on large screen shows scrollbar and wrapped header.
Using a smaller header removes the wrapping and scrollbar (, but makes the title less prominent).

**before:** 

![screen shot 2018-04-18 at 16 45 15](https://user-images.githubusercontent.com/1277621/38939312-ef4cf16e-4327-11e8-9f96-3261c44c29c8.png)

**after:** 
![screen shot 2018-04-18 at 16 46 45](https://user-images.githubusercontent.com/1277621/38939394-1f05a4dc-4328-11e8-99d2-73fe8cc4b2bf.png)

